### PR TITLE
[FEATURE] Run `composer normalize` after project generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-		"cpsit/project-builder": "^2.3",
+		"cpsit/project-builder": "^2.7",
 		"guzzlehttp/guzzle": "^7.0",
 		"nyholm/psr7": "^1.5",
 		"psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-		"cpsit/project-builder": "^2.2.4",
+		"cpsit/project-builder": "^2.3",
 		"guzzlehttp/guzzle": "^7.0",
 		"nyholm/psr7": "^1.5",
 		"psr/http-client": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74783c66c7c76329c75de671057c18a9",
+    "content-hash": "a5fb68c1f2404d25b59c1140d9ed1198",
     "packages": [
         {
             "name": "cocur/slugify",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc45de61d643a47f956b4f039b71a86b",
+    "content-hash": "74783c66c7c76329c75de671057c18a9",
     "packages": [
         {
             "name": "cocur/slugify",

--- a/config.yaml
+++ b/config.yaml
@@ -37,11 +37,8 @@ steps:
   # run shell commands on the local machine
   - type: runCommand
     options:
-      command: "composer update"
-      skipConfirmation: true
-  - type: runCommand
-    options:
-    command: "composer normalize"
+      command: "composer update && composer normalize"
+      # todo: allow-failure: true
 properties:
   # Package
   - identifier: package

--- a/config.yaml
+++ b/config.yaml
@@ -34,11 +34,14 @@ steps:
           target: 'LICENSE'
   - type: generateBuildArtifact
   - type: mirrorProcessedFiles
+  # run shell commands on the local machine
   - type: runCommand
     options:
-      command: "composer normalize"
+      command: "composer update"
       skipConfirmation: true
-
+  - type: runCommand
+    options:
+    command: "composer normalize"
 properties:
   # Package
   - identifier: package

--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,6 @@ steps:
           target: 'LICENSE'
   - type: generateBuildArtifact
   - type: mirrorProcessedFiles
-  # run shell commands on the local machine
   - type: runCommand
     options:
       command: "composer update && composer normalize"

--- a/config.yaml
+++ b/config.yaml
@@ -38,7 +38,7 @@ steps:
   - type: runCommand
     options:
       command: "composer update && composer normalize"
-      # todo: allow-failure: true
+      allowFailure: true
 properties:
   # Package
   - identifier: package

--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,10 @@ steps:
           target: 'LICENSE'
   - type: generateBuildArtifact
   - type: mirrorProcessedFiles
+  - type: runCommand
+    options:
+      command: "composer normalize"
+      skipConfirmation: true
 
 properties:
   # Package


### PR DESCRIPTION
With the most recently release of the `cpsit/project-builder` it is now possible to configure shell commands to be executed during the project generation. Acknowledging that `composer.json.twig` still lacks a clean syntax I propose to have `composer normalize` be executed in the target project directory to clean up the `composer.json`.

```yaml
- type: runCommand
  options:
    command: "composer normalize"
    allowFailure: true
```

Since the `runCommand` feature is only available since `v2.3` and its `allowFailure` config since `v2.7` I have bumped the requirement accordingly.