### PR TITLE
[BUGFIX] Run all linters and schema validation in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -50,6 +50,14 @@ jobs:
         run: composer lint:editorconfig
       - name: Lint PHP
         run: composer lint:php
+      - name: Lint Twig templates
+        run: composer lint:twig
+      - name: Lint YAML files
+        run: composer lint:yaml
+
+      # Schema
+      - name: Validate config.yaml against JSON schema
+        run: composer validate-schema
 
       # SCA
       - name: SCA PHP


### PR DESCRIPTION
This PR assures that `composer lint:twig` and `composer lint:yaml` are executed in CGL workflow. In addition, schema validation with `composer validate-schema` is now executed as well.