### PR TITLE
[BUGFIX] Assure trailing comma for various states in composer.json

### DIFF
--- a/templates/src/composer.json.twig
+++ b/templates/src/composer.json.twig
@@ -71,11 +71,12 @@
 		],
 		"lint:composer": "@fix:composer --dry-run",
 		"lint:editorconfig": "ec",
-		"lint:php": "@fix:php --dry-run"{% if dependencies.rector %},
+		"lint:php": "@fix:php --dry-run"{% if dependencies.rector or dependencies.phpstan or dependencies.phpunit %},{% endif %}
+{% if dependencies.rector %}
 		"migration": [
 			"@migration:rector"
 		],
-		"migration:rector": "rector process -c rector.php"{% if dependencies.phpstan %},{% endif %}
+		"migration:rector": "rector process -c rector.php"{% if dependencies.phpstan or dependencies.phpunit %},{% endif %}
 {% endif %}
 {% if dependencies.phpstan %}
 		"sca": [


### PR DESCRIPTION
This PR assures a trailing comma is added to the `lint:php` Composer script if any of the following scripts will be added.