### PR TITLE
[TASK] Include GitHub workflow templates in Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,5 +26,10 @@
 			],
 			"datasourceTemplate": "packagist"
 		}
-	]
+	],
+	"github-actions": {
+		"fileMatch": [
+			"^templates/src/\\.github/workflows/.+\\.yaml(\\.twig)?$"
+		]
+	}
 }


### PR DESCRIPTION
This PR extends the `github-actions` manager of Renovate to perform updates for workflow templates as well.