### PR TITLE
[FEATURE] Switch from branch protection rules to rulesets

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -70,29 +70,46 @@ labels:
     color: '#ffffff'
     description: 'This will not be worked on'
 
-# Branch protection rules
-branches:
-  - name: 'main'
-    protection:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-      required_status_checks:
-        strict: true
-        contexts:
-          - 'cgl'
-          - 'Tests (PHP 8.1 & locked dependencies)'
-          - 'Tests (PHP 8.1 & highest dependencies)'
-          - 'Tests (PHP 8.1 & lowest dependencies)'
-          - 'Tests (PHP 8.2 & locked dependencies)'
-          - 'Tests (PHP 8.2 & highest dependencies)'
-          - 'Tests (PHP 8.2 & lowest dependencies)'
-          - 'Tests (PHP 8.3 & locked dependencies)'
-          - 'Tests (PHP 8.3 & highest dependencies)'
-          - 'Tests (PHP 8.3 & lowest dependencies)'
-          - 'Test coverage'
-          - 'coverage/coveralls'
-      enforce_admins: false
-      required_linear_history: true
-      restrictions: ~
+# Rulesets
+rulesets:
+  - name: CI
+    target: branch
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+    rules:
+      - type: deletion
+      - type: non_fast_forward
+      - type: required_status_checks
+        parameters:
+          strict_required_status_checks_policy: true
+          do_not_enforce_on_create: false
+          required_status_checks:
+            - context: 'cgl'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.1 & locked dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.1 & highest dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.1 & lowest dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.2 & locked dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.2 & highest dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.2 & lowest dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.3 & locked dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.3 & highest dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP 8.3 & lowest dependencies)'
+              integration_id: 15368
+            - context: 'Test coverage'
+              integration_id: 15368
+    bypass_actors:
+      - actor_id: 5
+        actor_type: RepositoryRole
+        bypass_mode: always

--- a/templates/src/.github/settings.yml.twig
+++ b/templates/src/.github/settings.yml.twig
@@ -71,27 +71,36 @@ labels:
     color: '#ffffff'
     description: 'This will not be worked on'
 
-# Branch protection rules
-branches:
-  - name: 'main'
-    protection:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: true
-      required_status_checks:
-        strict: true
-        contexts:
-          - 'cgl'
+# Rulesets
+rulesets:
+  - name: CI
+    target: branch
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - ~DEFAULT_BRANCH
+    rules:
+      - type: deletion
+      - type: non_fast_forward
+      - type: required_status_checks
+        parameters:
+          strict_required_status_checks_policy: true
+          do_not_enforce_on_create: false
+          required_status_checks:
+            - context: 'cgl'
+              integration_id: 15368
 {% for php_version in dependencies.php %}
-          - 'Tests (PHP {{ php_version }} & locked dependencies)'
-          - 'Tests (PHP {{ php_version }} & highest dependencies)'
-          - 'Tests (PHP {{ php_version }} & lowest dependencies)'
+            - context: 'Tests (PHP {{ php_version }} & locked dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP {{ php_version }} & highest dependencies)'
+              integration_id: 15368
+            - context: 'Tests (PHP {{ php_version }} & lowest dependencies)'
+              integration_id: 15368
 {% endfor %}
-          - 'Test coverage'
-{% if ci.coveralls %}
-          - 'coverage/coveralls'
-{% endif %}
-      enforce_admins: false
-      required_linear_history: true
-      restrictions: ~
+            - context: 'Test coverage'
+              integration_id: 15368
+    bypass_actors:
+      - actor_id: 5
+        actor_type: RepositoryRole
+        bypass_mode: always


### PR DESCRIPTION
Since the Settings App [now supports repository rulesets](https://github.com/repository-settings/app/blob/master/docs/plugins/rulesets.md#repository-rulesets), this PR switches from branch protection rules to repository rules.