### PR TITLE
[BUGFIX] Enforce correct visibility of the resulting repository

### DIFF
--- a/templates/src/.github/settings.yml.twig
+++ b/templates/src/.github/settings.yml.twig
@@ -2,7 +2,8 @@ repository:
   name: '{{ repository.name }}'
   description: '{{ package.description }}'
   topics: '{{ repository.topics }}'
-  private: false
+  private: {% if repository.createResult.object.private ?? false %}true{% else %}false{% endif %}
+
   has_issues: true
   has_projects: false
   has_wiki: false


### PR DESCRIPTION
This PR fixes the repo visibility setting defined in `.github/settings.yml` to actually respect the configured visibility.