### PR TITLE
[BUGFIX] Make post-build `composer normalize` command execution optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-		"cpsit/project-builder": "^2.7",
+		"cpsit/project-builder": "^2.11",
 		"guzzlehttp/guzzle": "^7.0",
 		"nyholm/psr7": "^1.5",
 		"psr/http-client": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d2a6c96203ee38c137cb087d68580bd",
+    "content-hash": "f82a95c19c54fe64857afffc99cd41e5",
     "packages": [
         {
             "name": "cocur/slugify",

--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,7 @@ steps:
     options:
       command: "composer update && composer normalize"
       allowFailure: true
+      required: false
 properties:
   # Package
   - identifier: package


### PR DESCRIPTION
Project generation must not fail if the user decides to *not* run `composer normalize` after project files are built. Hence, we mark the command execution as optional.

Requires https://github.com/CPS-IT/project-builder/pull/620 to be merged and released first.